### PR TITLE
Fix instructions on building from Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ docker pull asmagin/jenkins-on-windowsservercore
 
 *Alternatively, you can build an image from Dockerfile:*
 ``` sh
-docker build -t='asmagin/jenkins-on-windowsservercore' 'https://github.com/asmagin/jenkins-on-windowsservercore#master:master')
+docker build -t="asmagin/jenkins-on-windowsservercore" "https://github.com/asmagin/jenkins-on-windowsservercore.git#master:master"
 
 # or
 
-docker build -t="asmagin/jenkins-on-windowsservercore" 'https://github.com/asmagin/jenkins-on-windowsservercore#master:slave')
+docker build -t="asmagin/jenkins-on-windowsservercore" "https://github.com/asmagin/jenkins-on-windowsservercore.git#master:slave"
 ```
 
 ## Usage


### PR DESCRIPTION
Remove bad parenthesis from end of lines.
Add missing ".git" to repository paths.
Change quotes to doubles (Docker doesn't understand the single quotes, at least not in a plain command prompt).