### PR TITLE
Fix SecurityProtocol parse error due to double quotes

### DIFF
--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -16,7 +16,7 @@ RUN \
     if (-not($env:JENKINS_UC)) { $env:JENKINS_UC = 'https://updates.jenkins.io'; \
         [Environment]::SetEnvironmentVariable('JENKINS_UC', $env:JENKINS_UC, 'Machine') }; \
     New-Item -ItemType Directory -Force -Path 'c:/jenkins'; \
-    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11"; \
+    [Net.ServicePointManager]::SecurityProtocol = 'tls12'; \
     Invoke-WebRequest "https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/$env:JENKINS_VERSION/jenkins-war-$env:JENKINS_VERSION.war" -OutFile "c:/jenkins.war" -UseBasicParsing
 
 # Note: Install Git
@@ -24,7 +24,7 @@ RUN \
     if (-not($env:GIT_VERSION)) { $env:GIT_VERSION = '2.12.2'; \
         [Environment]::SetEnvironmentVariable('GIT_VERSION', $env:GIT_VERSION, 'Machine') }; \
     New-Item -ItemType Directory -Force -Path 'c:/git'; \
-    [Net.ServicePointManager]::SecurityProtocol = "tls12, tls11"; \
+    [Net.ServicePointManager]::SecurityProtocol = 'tls12'; \
     Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v$env:GIT_VERSION.windows.1/Git-$env:GIT_VERSION-64-bit.exe" -OutFile "$env:TEMP/git.exe" -UseBasicParsing; \
     Start-Process -FilePath "$env:TEMP/git.exe" -ArgumentList '/VERYSILENT', '/NORESTART', '/NOCANCEL', '/SP-', '/DIR="c:/git"' -PassThru | Wait-Process; \
     dir "$env:TEMP" | Remove-Item -Force -Recurse -ErrorAction SilentlyContinue


### PR DESCRIPTION
Also limit to TLS1.2 which is used by the referenced websites - older protocols are unsafe.